### PR TITLE
Updated existing tests to use current time and dates

### DIFF
--- a/tests/test_skyscanner.py
+++ b/tests/test_skyscanner.py
@@ -9,6 +9,7 @@ Tests for `skyscanner` module.
 """
 
 import unittest
+from datetime import datetime, timedelta
 
 from skyscanner.skyscanner import Flights, Transport, FlightsCache, CarHire, Hotels
 
@@ -18,7 +19,11 @@ class TestCarHire(unittest.TestCase):
         # API Key that's meant for testing only
         # Taken from: http://business.skyscanner.net/portal/en-GB/Documentation/FlightsLivePricingQuickStart
         self.api_key = 'prtl6749387986743898559646983194'
-        pass
+        datetime_format = '%Y-%m-%dT%H:%S'
+        pickup_datetime = datetime.now()
+        dropoff_datetime = pickup_datetime + timedelta(days=3)
+        self.pickup = pickup_datetime.strftime(datetime_format)
+        self.dropoff = dropoff_datetime.strftime(datetime_format)
 
     def test_location_autosuggest(self):
         carhire_service = CarHire(self.api_key)
@@ -44,8 +49,8 @@ class TestCarHire(unittest.TestCase):
             locale='en-GB',
             pickupplace='LHR-sky',
             dropoffplace='LHR-sky',
-            pickupdatetime='2015-05-25T12:00',
-            dropoffdatetime='2015-05-25T18:00',
+            pickupdatetime=self.pickup,
+            dropoffdatetime=self.dropoff,
             driverage='30',
             userip='175.156.244.174')
 
@@ -64,8 +69,8 @@ class TestCarHire(unittest.TestCase):
             locale='en-GB',
             pickupplace='LHR-sky',
             dropoffplace='LHR-sky',
-            pickupdatetime='2015-05-28T12:00',
-            dropoffdatetime='2015-05-31T12:00',
+            pickupdatetime=self.pickup,
+            dropoffdatetime=self.dropoff,
             driverage='30',
             userip='175.156.244.174')
 
@@ -81,7 +86,11 @@ class TestHotels(unittest.TestCase):
         # Taken from: http://business.skyscanner.net/portal/en-GB/Documentation/FlightsLivePricingQuickStart
 
         self.api_key = 'prtl6749387986743898559646983194'
-        pass
+        datetime_format = '%Y-%m-%d'
+        checkin_datetime = datetime.now()
+        checkout_datetime = checkin_datetime + timedelta(days=4)
+        self.checkin = checkin_datetime.strftime(datetime_format)
+        self.checkout = checkout_datetime.strftime(datetime_format)
 
     def test_location_autosuggest(self):
         hotels_service = Hotels(self.api_key)
@@ -106,12 +115,12 @@ class TestHotels(unittest.TestCase):
             currency='GBP',
             locale='en-GB',
             entityid=27543923,
-            checkindate='2015-05-26',
-            checkoutdate='2015-05-30',
+            checkindate=self.checkin,
+            checkoutdate=self.checkout,
             guests=1,
             rooms=1)
 
-        self.assertTrue(len(result['places']) > 0)
+        self.assertTrue(len(result['hotels']) > 0)
 
     def test_create_session(self):
         """
@@ -125,8 +134,8 @@ class TestHotels(unittest.TestCase):
             currency='GBP',
             locale='en-GB',
             entityid=27543923,
-            checkindate='2015-05-26',
-            checkoutdate='2015-05-30',
+            checkindate=self.checkin,
+            checkoutdate=self.checkout,
             guests=1,
             rooms=1)
 
@@ -143,7 +152,16 @@ class TestFlights(unittest.TestCase):
         # Taken from: http://business.skyscanner.net/portal/en-GB/Documentation/FlightsLivePricingQuickStart
 
         self.api_key = 'prtl6749387986743898559646983194'
-        pass
+        datetime_format = '%Y-%m'
+        outbound_datetime = datetime.now()
+        inbound_datetime = outbound_datetime + timedelta(days=31)
+        self.outbound = outbound_datetime.strftime(datetime_format)
+        self.inbound = inbound_datetime.strftime(datetime_format)
+
+        datetime_format = '%Y-%m-%d'
+        inbound_datetime = outbound_datetime + timedelta(days=3)
+        self.outbound_days = outbound_datetime.strftime(datetime_format)
+        self.inbound_days = inbound_datetime.strftime(datetime_format)
 
     def test_get_cheapest_quotes(self):
         flights_cache_service = FlightsCache(self.api_key)
@@ -153,8 +171,8 @@ class TestFlights(unittest.TestCase):
             locale='en-GB',
             originplace='SIN-sky',
             destinationplace='KUL-sky',
-            outbounddate='2015-05',
-            inbounddate='2015-06')
+            outbounddate=self.outbound,
+            inbounddate=self.inbound)
 
         self.assertTrue(len(result['Quotes']) > 0)
 
@@ -168,8 +186,8 @@ class TestFlights(unittest.TestCase):
             locale='en-GB',
             originplace='SIN-sky',
             destinationplace='KUL-sky',
-            outbounddate='2015-05',
-            inbounddate='2015-06')
+            outbounddate=self.outbound,
+            inbounddate=self.inbound)
 
         print("result: %s" % result)
 
@@ -181,8 +199,8 @@ class TestFlights(unittest.TestCase):
             locale='en-GB',
             originplace='SIN-sky',
             destinationplace='KUL-sky',
-            outbounddate='2015-05',
-            inbounddate='2015-06')
+            outbounddate=self.outbound,
+            inbounddate=self.inbound)
 
         self.assertTrue(len(result['Quotes']) > 0)
 
@@ -194,8 +212,8 @@ class TestFlights(unittest.TestCase):
             locale='en-GB',
             originplace='SIN-sky',
             destinationplace='KUL-sky',
-            outbounddate='2015-05',
-            inbounddate='2015-06')
+            outbounddate=self.outbound,
+            inbounddate=self.inbound)
 
         self.assertTrue(len(result['Dates']) > 0)
 
@@ -207,8 +225,8 @@ class TestFlights(unittest.TestCase):
             locale='en-GB',
             originplace='SIN-sky',
             destinationplace='KUL-sky',
-            outbounddate='2015-05-28',
-            inbounddate='2015-05-31',
+            outbounddate=self.outbound_days,
+            inbounddate=self.inbound_days,
             adults=1)
 
         self.assertTrue(poll_url)
@@ -278,8 +296,8 @@ class TestFlights(unittest.TestCase):
             locale='en-GB',
             originplace='SIN-sky',
             destinationplace='KUL-sky',
-            outbounddate='2015-05-28',
-            inbounddate='2015-05-31',
+            outbounddate=self.outbound_days,
+            inbounddate=self.inbound_days,
             adults=1)
 
         # print(result)

--- a/tests/test_skyscanner.py
+++ b/tests/test_skyscanner.py
@@ -12,6 +12,7 @@ import unittest
 
 from skyscanner.skyscanner import Flights, Transport, FlightsCache, CarHire, Hotels
 
+
 class TestCarHire(unittest.TestCase):
     def setUp(self):
         # API Key that's meant for testing only
@@ -23,28 +24,28 @@ class TestCarHire(unittest.TestCase):
         carhire_service = CarHire(self.api_key)
 
         result = carhire_service.location_autosuggest(
-            market='UK', 
-            currency='GBP', 
-            locale='en-GB', 
+            market='UK',
+            currency='GBP',
+            locale='en-GB',
             query='Kuala')
 
         self.assertTrue(len(result['results']) > 0)
 
     def test_get_result(self):
         """
-        http://partners.api.skyscanner.net/apiservices/carhire/liveprices/v2/{market}/{currency}/{locale}/{pickupplace}/{dropoffplace}/{pickupdatetime}/{dropoffdatetime}/{driverage}?apiKey={apiKey}&userip={userip} 
+        http://partners.api.skyscanner.net/apiservices/carhire/liveprices/v2/{market}/{currency}/{locale}/{pickupplace}/{dropoffplace}/{pickupdatetime}/{dropoffdatetime}/{driverage}?apiKey={apiKey}&userip={userip}
         YYYY-MM-DDThh:mm
         """
         carhire_service = CarHire(self.api_key)
 
         result = carhire_service.get_result(
-            market='UK', 
-            currency='GBP', 
-            locale='en-GB', 
-            pickupplace='LHR-sky', 
-            dropoffplace='LHR-sky', 
-            pickupdatetime='2015-05-25T12:00', 
-            dropoffdatetime='2015-05-25T18:00', 
+            market='UK',
+            currency='GBP',
+            locale='en-GB',
+            pickupplace='LHR-sky',
+            dropoffplace='LHR-sky',
+            pickupdatetime='2015-05-25T12:00',
+            dropoffdatetime='2015-05-25T18:00',
             driverage='30',
             userip='175.156.244.174')
 
@@ -52,27 +53,27 @@ class TestCarHire(unittest.TestCase):
 
     def test_create_session(self):
         """
-        http://partners.api.skyscanner.net/apiservices/carhire/liveprices/v2/{market}/{currency}/{locale}/{pickupplace}/{dropoffplace}/{pickupdatetime}/{dropoffdatetime}/{driverage}?apiKey={apiKey}&userip={userip} 
+        http://partners.api.skyscanner.net/apiservices/carhire/liveprices/v2/{market}/{currency}/{locale}/{pickupplace}/{dropoffplace}/{pickupdatetime}/{dropoffdatetime}/{driverage}?apiKey={apiKey}&userip={userip}
         YYYY-MM-DDThh:mm
         """
         carhire_service = CarHire(self.api_key)
 
         poll_url = carhire_service.create_session(
-            market='UK', 
-            currency='GBP', 
-            locale='en-GB', 
-            pickupplace='LHR-sky', 
-            dropoffplace='LHR-sky', 
-            pickupdatetime='2015-05-28T12:00', 
-            dropoffdatetime='2015-05-31T12:00', 
+            market='UK',
+            currency='GBP',
+            locale='en-GB',
+            pickupplace='LHR-sky',
+            dropoffplace='LHR-sky',
+            pickupdatetime='2015-05-28T12:00',
+            dropoffdatetime='2015-05-31T12:00',
             driverage='30',
             userip='175.156.244.174')
 
         self.assertTrue(poll_url)
 
     def tearDown(self):
-        pass        
-        
+        pass
+
 
 class TestHotels(unittest.TestCase):
     def setUp(self):
@@ -86,53 +87,53 @@ class TestHotels(unittest.TestCase):
         hotels_service = Hotels(self.api_key)
 
         result = hotels_service.location_autosuggest(
-            market='UK', 
-            currency='GBP', 
-            locale='en-GB', 
+            market='UK',
+            currency='GBP',
+            locale='en-GB',
             query='Kuala')
 
         self.assertTrue(len(result['results']) > 0)
 
     def test_get_result(self):
         """
-        http://partners.api.skyscanner.net/apiservices/carhire/liveprices/v2/{market}/{currency}/{locale}/{pickupplace}/{dropoffplace}/{pickupdatetime}/{dropoffdatetime}/{driverage}?apiKey={apiKey}&userip={userip} 
+        http://partners.api.skyscanner.net/apiservices/carhire/liveprices/v2/{market}/{currency}/{locale}/{pickupplace}/{dropoffplace}/{pickupdatetime}/{dropoffdatetime}/{driverage}?apiKey={apiKey}&userip={userip}
         YYYY-MM-DDThh:mm
         """
 
         hotels_service = Hotels(self.api_key)
         result = hotels_service.get_result(
-            market='UK', 
-            currency='GBP', 
-            locale='en-GB', 
-            entityid=27543923, 
-            checkindate='2015-05-26', 
-            checkoutdate='2015-05-30', 
-            guests=1, 
+            market='UK',
+            currency='GBP',
+            locale='en-GB',
+            entityid=27543923,
+            checkindate='2015-05-26',
+            checkoutdate='2015-05-30',
+            guests=1,
             rooms=1)
 
         self.assertTrue(len(result['places']) > 0)
 
     def test_create_session(self):
         """
-        http://partners.api.skyscanner.net/apiservices/carhire/liveprices/v2/{market}/{currency}/{locale}/{pickupplace}/{dropoffplace}/{pickupdatetime}/{dropoffdatetime}/{driverage}?apiKey={apiKey}&userip={userip} 
+        http://partners.api.skyscanner.net/apiservices/carhire/liveprices/v2/{market}/{currency}/{locale}/{pickupplace}/{dropoffplace}/{pickupdatetime}/{dropoffdatetime}/{driverage}?apiKey={apiKey}&userip={userip}
         YYYY-MM-DDThh:mm
         """
         hotels_service = Hotels(self.api_key)
 
         poll_url = hotels_service.create_session(
-            market='UK', 
-            currency='GBP', 
-            locale='en-GB', 
-            entityid=27543923, 
-            checkindate='2015-05-26', 
-            checkoutdate='2015-05-30', 
-            guests=1, 
+            market='UK',
+            currency='GBP',
+            locale='en-GB',
+            entityid=27543923,
+            checkindate='2015-05-26',
+            checkoutdate='2015-05-30',
+            guests=1,
             rooms=1)
 
         self.assertTrue(poll_url)
 
     def tearDown(self):
-        pass        
+        pass
 
 
 class TestFlights(unittest.TestCase):
@@ -148,41 +149,39 @@ class TestFlights(unittest.TestCase):
         flights_cache_service = FlightsCache(self.api_key)
         result = flights_cache_service.get_cheapest_quotes(
             country='UK',
-            currency='GBP', 
-            locale='en-GB', 
-            originplace='SIN-sky', 
-            destinationplace='KUL-sky', 
-            outbounddate='2015-05', 
+            currency='GBP',
+            locale='en-GB',
+            originplace='SIN-sky',
+            destinationplace='KUL-sky',
+            outbounddate='2015-05',
             inbounddate='2015-06')
 
-        self.assertTrue(len(result['Quotes']) > 0)        
-
+        self.assertTrue(len(result['Quotes']) > 0)
 
     # I'm getting the following result:
-    # {u'ValidationErrors': [{u'Message': u'For this query please use the following service [BrowseDates]'}]}        
+    # {u'ValidationErrors': [{u'Message': u'For this query please use the following service [BrowseDates]'}]}
     def test_get_cheapest_price_by_route(self):
         flights_cache_service = FlightsCache(self.api_key)
         result = flights_cache_service.get_cheapest_price_by_route(
             country='UK',
-            currency='GBP', 
-            locale='en-GB', 
-            originplace='SIN-sky', 
-            destinationplace='KUL-sky', 
-            outbounddate='2015-05', 
+            currency='GBP',
+            locale='en-GB',
+            originplace='SIN-sky',
+            destinationplace='KUL-sky',
+            outbounddate='2015-05',
             inbounddate='2015-06')
 
         print("result: %s" % result)
-
 
     def test_get_cheapest_price_by_date(self):
         flights_cache_service = FlightsCache(self.api_key)
         result = flights_cache_service.get_cheapest_price_by_date(
             country='UK',
-            currency='GBP', 
-            locale='en-GB', 
-            originplace='SIN-sky', 
-            destinationplace='KUL-sky', 
-            outbounddate='2015-05', 
+            currency='GBP',
+            locale='en-GB',
+            originplace='SIN-sky',
+            destinationplace='KUL-sky',
+            outbounddate='2015-05',
             inbounddate='2015-06')
 
         self.assertTrue(len(result['Quotes']) > 0)
@@ -191,26 +190,25 @@ class TestFlights(unittest.TestCase):
         flights_cache_service = FlightsCache(self.api_key)
         result = flights_cache_service.get_grid_prices_by_date(
             country='UK',
-            currency='GBP', 
-            locale='en-GB', 
-            originplace='SIN-sky', 
-            destinationplace='KUL-sky', 
-            outbounddate='2015-05', 
+            currency='GBP',
+            locale='en-GB',
+            originplace='SIN-sky',
+            destinationplace='KUL-sky',
+            outbounddate='2015-05',
             inbounddate='2015-06')
 
         self.assertTrue(len(result['Dates']) > 0)
-
 
     def test_create_session(self):
         flights_service = Flights(self.api_key)
         poll_url = flights_service.create_session(
             country='UK',
-            currency='GBP', 
-            locale='en-GB', 
-            originplace='SIN-sky', 
-            destinationplace='KUL-sky', 
-            outbounddate='2015-05-28', 
-            inbounddate='2015-05-31', 
+            currency='GBP',
+            locale='en-GB',
+            originplace='SIN-sky',
+            destinationplace='KUL-sky',
+            outbounddate='2015-05-28',
+            inbounddate='2015-05-31',
             adults=1)
 
         self.assertTrue(poll_url)
@@ -227,18 +225,17 @@ class TestFlights(unittest.TestCase):
 
         self.assertTrue(len(result['Places']) > 0)
 
-
     # def test_poll_session(self):
     #     flights_service = Flights(self.api_key)
 
     #     poll_url = flights_service.create_session(
-    #         country='UK', 
-    #         currency='GBP', 
-    #         locale='en-GB', 
-    #         originplace='SIN-sky', 
-    #         destinationplace='KUL-sky', 
-    #         outbounddate='2015-05-28', 
-    #         inbounddate='2015-05-31', 
+    #         country='UK',
+    #         currency='GBP',
+    #         locale='en-GB',
+    #         originplace='SIN-sky',
+    #         destinationplace='KUL-sky',
+    #         outbounddate='2015-05-28',
+    #         inbounddate='2015-05-31',
     #         adults=1)
 
     #     result = flights_service.poll_session(poll_url, sorttype='carrier')
@@ -251,13 +248,13 @@ class TestFlights(unittest.TestCase):
     #     flights_service = Flights(self.api_key)
 
     #     poll_url = flights_service.create_session(
-    #         country='UK', 
-    #         currency='GBP', 
-    #         locale='en-GB', 
-    #         originplace='SIN-sky', 
-    #         destinationplace='KUL-sky', 
-    #         outbounddate='2015-05-28', 
-    #         inbounddate='2015-05-31', 
+    #         country='UK',
+    #         currency='GBP',
+    #         locale='en-GB',
+    #         originplace='SIN-sky',
+    #         destinationplace='KUL-sky',
+    #         outbounddate='2015-05-28',
+    #         inbounddate='2015-05-31',
     #         adults=1)
 
     #     flights_results = flights_service.poll_session(poll_url, sorttype='carrier')
@@ -266,28 +263,28 @@ class TestFlights(unittest.TestCase):
 
     #     itinerary = flights_results['Itineraries'][0]
 
-    #     result = flights_service.request_booking_details(poll_url, outboundlegid=itinerary['OutboundLegId'], inboundlegid=itinerary['InboundLegId'])
+    #     result = flights_service.request_booking_details(poll_url, outboundlegid=itinerary['OutboundLegId'],
+    #                                                      inboundlegid=itinerary['InboundLegId'])
 
     #     print(result)
 
-    #     pass            
+    #     pass
 
     def test_get_result(self):
         flights_service = Flights(self.api_key)
         result = flights_service.get_result(
-            country='UK', 
-            currency='GBP', 
-            locale='en-GB', 
-            originplace='SIN-sky', 
-            destinationplace='KUL-sky', 
-            outbounddate='2015-05-28', 
-            inbounddate='2015-05-31', 
+            country='UK',
+            currency='GBP',
+            locale='en-GB',
+            originplace='SIN-sky',
+            destinationplace='KUL-sky',
+            outbounddate='2015-05-28',
+            inbounddate='2015-05-31',
             adults=1)
 
         # print(result)
         print("status: %s" % result['Status'])
-        # self.assertTrue(len(result['Flights']['Itineraries']) > 0)        
-
+        # self.assertTrue(len(result['Flights']['Itineraries']) > 0)
 
     def tearDown(self):
         pass


### PR DESCRIPTION
Hi, two commits in this pull request. The first one is just formatting, no actual code changes there. The seconds one contains the actual change.

We are about to use SkyScanner APIs in my company and since Python is one of our main tools, we are looking forward to use and contribute to this SDK.

I also have a question related to those tests: it seems that throttling is making them fail from time to time, do you think if it is possible to do something about that? Maybe use some specific 'unit test' key?

Cheers,
Denis